### PR TITLE
已修复字幕链路中的两个核心问题（短句漏翻、重复/超长错位），并补上标签污染防护。

### DIFF
--- a/src/SRT/srt.py
+++ b/src/SRT/srt.py
@@ -410,6 +410,22 @@ class SrtScript(object):
             seg.remove_trans_punc()
         self.task_logger.info("Removed punctuation in translation.")
 
+    @staticmethod
+    def _clean_translation_text(text: str) -> str:
+        """
+        Remove prompt-label artifacts occasionally echoed by LLM output.
+        This keeps actual subtitle content intact while stripping residual
+        labels like 'Your translation:' / '你的翻译：'.
+        """
+        cleaned = text
+        # Remove English prompt labels (case-insensitive), with optional colon.
+        cleaned = re.sub(r"(?i)\byour\s+translation\b\s*[:：]?", "", cleaned)
+        # Remove Chinese prompt labels, with optional colon.
+        cleaned = re.sub(r"你的翻译\s*[:：]?", "", cleaned)
+        # Normalize extra spaces created by removals.
+        cleaned = re.sub(r"[ \t]{2,}", " ", cleaned)
+        return cleaned.strip()
+
     def set_translation(self, translate: str, id_range: tuple, model, video_name, video_link=None):
         segments = translate.strip().split('\n\n')
         expected_len = id_range[1] - id_range[0] 
@@ -419,7 +435,7 @@ class SrtScript(object):
 
         for i, seg in enumerate(self.segments[id_range[0]-1:id_range[1]]):
             if i < len(segments):
-                seg.translation = segments[i].strip()
+                seg.translation = self._clean_translation_text(segments[i].strip())
                 print("NO missing")
                 print(seg.translation)
             else:
@@ -570,33 +586,48 @@ class SrtScript(object):
         trans_seg1 = translation[:trans_split_idx]
         trans_seg2 = translation[trans_split_idx:]
 
-        start_seg1 = seg.start
-        end_seg1 = start_seg2 = seg.start + (seg.end_time - seg.start_time) * time_split_ratio
+        # SrtSegment uses start_time/end_time; legacy fields (start/end) do not exist.
+        start_seg1 = seg.start_time
+        end_seg1 = start_seg2 = seg.start_time + (seg.end_time - seg.start_time) * time_split_ratio
         end_seg2 = seg.end_time
 
         seg1_dict = {}
-        seg1_dict['text'] = src_seg1
-        seg1_dict['start'] = start_seg1
-        seg1_dict['end'] = end_seg1
-        seg1 = SrtSegment(self.src_lang, self.tgt_lang, seg1_dict)
+        seg1_dict["text"] = src_seg1
+        seg1_dict["start"] = start_seg1
+        seg1_dict["end"] = end_seg1
+        seg1 = SrtSegment(
+            self.src_lang,
+            self.tgt_lang,
+            src_text=seg1_dict["text"],
+            start_time=seg1_dict["start"],
+            end_time=seg1_dict["end"],
+        )
         seg1.translation = trans_seg1
 
         seg2_dict = {}
-        seg2_dict['text'] = src_seg2
-        seg2_dict['start'] = start_seg2
-        seg2_dict['end'] = end_seg2
-        seg2 = SrtSegment(self.src_lang, self.tgt_lang, seg2_dict)
+        seg2_dict["text"] = src_seg2
+        seg2_dict["start"] = start_seg2
+        seg2_dict["end"] = end_seg2
+        seg2 = SrtSegment(
+            self.src_lang,
+            self.tgt_lang,
+            src_text=seg2_dict["text"],
+            start_time=seg2_dict["start"],
+            end_time=seg2_dict["end"],
+        )
         seg2.translation = trans_seg2
 
         result_list = []
-        if len(seg1.translation) > text_threshold and (seg1.end - seg1.start) > time_threshold:
+        if len(seg1.translation) > text_threshold and (seg1.end_time - seg1.start_time) > time_threshold:
             result_list += self.split_seg(seg1, text_threshold, time_threshold)
         else:
+            seg1.update_timestamps()
             result_list.append(seg1)
 
-        if len(seg2.translation) > text_threshold and (seg2.end - seg2.start) > time_threshold:
+        if len(seg2.translation) > text_threshold and (seg2.end_time - seg2.start_time) > time_threshold:
             result_list += self.split_seg(seg2, text_threshold, time_threshold)
         else:
+            seg2.update_timestamps()
             result_list.append(seg2)
 
         return result_list

--- a/src/audio/VAD.py
+++ b/src/audio/VAD.py
@@ -21,7 +21,7 @@ logger = getLogger(__name__)
 
 
 class VAD(ABC):
-    def __init__(self, src_lang: str, tgt_lang: str, min_segment_seconds: float = 1.0):
+    def __init__(self, src_lang: str, tgt_lang: str, min_segment_seconds: float = 0.8):
         self.src_lang = src_lang
         self.tgt_lang = tgt_lang
         self.srt: SrtScript | None = None

--- a/src/audio/audio_agent.py
+++ b/src/audio/audio_agent.py
@@ -38,7 +38,7 @@ class AudioAgent(ABC):
                 src_lang=self.audio_config["src_lang"],
                 tgt_lang=self.audio_config["tgt_lang"],
                 min_segment_seconds=float(
-                    self.audio_config.get("min_segment_seconds", 1.0)
+                    self.audio_config.get("min_segment_seconds", 0.8)
                 ),
                 **provider_options,
             )

--- a/src/audio/vad_agent.py
+++ b/src/audio/vad_agent.py
@@ -21,7 +21,7 @@ class APIPyannoteVAD(VAD):
         self,
         src_lang: str,
         tgt_lang: str,
-        min_segment_seconds: float = 1.0,
+        min_segment_seconds: float = 0.8,
         *,
         model: str = "precision-2",
         api_token: str | None = None,
@@ -211,7 +211,7 @@ class LocalPyannoteVAD(VAD):
         model_name_or_path: str,
         src_lang: str,
         tgt_lang: str,
-        min_segment_seconds: float = 1.0,
+        min_segment_seconds: float = 0.8,
         *,
         hf_token: str | None = None,
         **pipeline_kwargs,
@@ -255,7 +255,7 @@ def create_vad(
     model_name_or_path: str,
     src_lang: str,
     tgt_lang: str,
-    min_segment_seconds: float = 1.0,
+    min_segment_seconds: float = 0.8,
     **provider_kwargs,
 ) -> VAD:
     """Factory helper returning the appropriate VAD provider implementation."""

--- a/src/task.py
+++ b/src/task.py
@@ -826,10 +826,10 @@ class Task:
         self.get_speaker_segments()
         self.get_visual_cues()
         self.transcribe()
-        # self.preprocess()
+        self.preprocess()
         self.translation()
 
-        # self.postprocess()
+        self.postprocess()
         self.proofread()
         self.editor()
         self.result = self.output_render()

--- a/src/translators/prompts.py
+++ b/src/translators/prompts.py
@@ -4,6 +4,7 @@ system_prompt = (
     "Keep every '\n' in the translated text in the corresponding place, and make sure to keep the same number of lines in the translated text. \n"
     "You must break the translated sentence into multiple lines accordingly if original text breaks a complete sentence into different lines\n"
     "You should only output the translated text line by line without any other notation. \n"
+    "Do not output labels or wrappers such as 'Your translation', 'Translation:', or '你的翻译'. Output only translated subtitle text. \n"
 )
 
 input_prompt_base = "You current task is to translate the script in the domain of {domain} from {source_language} to {target_language} \n"


### PR DESCRIPTION
本次改动：
0) min_segment_seconds: 1.0 -> 0.8
1) 恢复 preprocess()/postprocess()
2) 修复 SRT split 时间字段兼容问题
3) 增加双保险去除 Your translation/你的翻译（prompt + 回写清洗）